### PR TITLE
doc: fix a type in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For other features of lsp, such as `Defination`, `References`, `implementations`
 ```lua
 {
     "jinzhongjia/LspUI.nvim",
-    event="Verylazy",
+    event="VeryLazy",
     config=function()
         require("LspUI").setup()
     end


### PR DESCRIPTION
This event is unknown to the lazy.nvim.