### PR TITLE
fix: change code_action line diagnostic fetcher function

### DIFF
--- a/lua/LspUI/code_action/init.lua
+++ b/lua/LspUI/code_action/init.lua
@@ -51,9 +51,7 @@ M.run = function()
 		params = lsp.util.make_range_params()
 	end
 	local current_buffer = api.nvim_get_current_buf()
-	local diagnostics = vim.diagnostic.get(current_buffer, {
-		lnum = fn.line(".") - 1,
-	})
+	local diagnostics = lsp.diagnostic.get_line_diagnostics(current_buffer)
 	params.context = { diagnostics = diagnostics }
 	local ctx = { bufnr = current_buffer, method = method, params = params }
 	lsp.buf_request_all(current_buffer, method, params, function(results)

--- a/lua/LspUI/code_action/init.lua
+++ b/lua/LspUI/code_action/init.lua
@@ -51,10 +51,13 @@ M.run = function()
 		params = lsp.util.make_range_params()
 	end
 	local current_buffer = api.nvim_get_current_buf()
-	local diagnostics = lsp.diagnostic.get_line_diagnostics(current_buffer)
+  local diagnostics = vim.diagnostic.get(current_buffer, {
+ 	  lnum = vim.api.nvim_win_get_cursor(0)[1] - 1
+  })
 	params.context = { diagnostics = diagnostics }
 	local ctx = { bufnr = current_buffer, method = method, params = params }
 	lsp.buf_request_all(current_buffer, method, params, function(results)
+    print(vim.inspect(results))
 		local actions = {}
 		for client_id, result in pairs(results) do
 			for _, action in pairs(result.result or {}) do

--- a/lua/LspUI/code_action/init.lua
+++ b/lua/LspUI/code_action/init.lua
@@ -51,9 +51,9 @@ M.run = function()
 		params = lsp.util.make_range_params()
 	end
 	local current_buffer = api.nvim_get_current_buf()
-  local diagnostics = vim.diagnostic.get(current_buffer, {
- 	  lnum = vim.api.nvim_win_get_cursor(0)[1] - 1
-  })
+  local diagnostics = util.diagnostic_vim_to_lsp(vim.diagnostic.get(current_buffer, {
+		lnum = fn.line(".") - 1,
+	}))
 	params.context = { diagnostics = diagnostics }
 	local ctx = { bufnr = current_buffer, method = method, params = params }
 	lsp.buf_request_all(current_buffer, method, params, function(results)

--- a/lua/LspUI/code_action/init.lua
+++ b/lua/LspUI/code_action/init.lua
@@ -57,7 +57,6 @@ M.run = function()
 	params.context = { diagnostics = diagnostics }
 	local ctx = { bufnr = current_buffer, method = method, params = params }
 	lsp.buf_request_all(current_buffer, method, params, function(results)
-    print(vim.inspect(results))
 		local actions = {}
 		for client_id, result in pairs(results) do
 			for _, action in pairs(result.result or {}) do

--- a/lua/LspUI/code_action/util.lua
+++ b/lua/LspUI/code_action/util.lua
@@ -129,4 +129,26 @@ M.Exec_action = function(action_tuple, ctx)
 	end
 end
 
+M.diagnostic_vim_to_lsp = function(diagnostics)
+	return vim.tbl_map(function(diagnostic)
+		return vim.tbl_extend("keep", {
+			range = {
+				start = {
+					line = diagnostic.lnum,
+					character = diagnostic.col,
+				},
+				["end"] = {
+					line = diagnostic.end_lnum,
+					character = diagnostic.end_col,
+				},
+			},
+			severity = type(diagnostic.severity) == "string" and vim.diagnostic.severity[diagnostic.severity]
+				or diagnostic.severity,
+			message = diagnostic.message,
+			source = diagnostic.source,
+			code = diagnostic.code,
+		}, diagnostic.user_data and (diagnostic.user_data.lsp or {}) or {})
+	end, diagnostics)
+end
+
 return M


### PR DESCRIPTION
When using the `code_action` function with Rust LSP I got the following error message:
```lua
{ {
    error = {
      code = -32602,
      message = 'Failed to deserialize textDocument/codeAction: missing field `range`; {"range":{"end":{"line":3,"character":4},"start":{"line":3,"character":4}},"textDocument":{"uri":"file:///home/rodrigo/programations/pixel_prog/lets-
go/src/main.rs"},"context":{"diagnostics":[{"col":4,"message":"cannot find value `Instance` in this scope\\nnot found in this scope","lnum":3,"end_col":12,"bufnr":1,"namespace":21,"source":"rustc","severity":1,"user_data":{"lsp":{"codeD
escription":{"href":"https://doc.rust-lang.org/error-index.html#E0425"},"relatedInformation":[{"message":"consider importing this unit variant: `use wgpu::VertexStepMode::Instance;\\n`","location":{"uri":"file:///home/rodrigo/programati
ons/pixel_prog/lets-go/src/main.rs","range":{"end":{"line":0,"character":0},"start":{"line":0,"character":0}}}}],"code":"E0425","data":{"rendered":"error[E0425]: cannot find value `Instance` in this scope\\n --> src/main.rs:4:5\\n  |\\n
4 |     Instance;\\n  |     ^^^^^^^^ not found in this scope\\n  |\\nhelp: consider importing this unit variant\\n  |\\n1 + use wgpu::VertexStepMode::Instance;\\n  |\\n\\n"}}},"code":"E0425","end_lnum":3}]}}',
      <metatable> = {
        __tostring = <function 1>
      }
    }
  } }
```

Looking at the code I saw that the implementation of the logic to get the diagnostic from the current line was not align with the [lsputil code](https://github.com/neovim/neovim/blob/317c80f460a7826421f40f57ee8bdbd736b0f225/runtime/lua/vim/lsp/buf.lua#L757), which use: 
```lua
context.diagnostics = vim.lsp.diagnostic.get_line_diagnostics(bufnr)
```

Changing the diagnostic fetcher logic to use the ` vim.lsp.diagnostic.get_line_diagnostics(bufnr)` function fixes the problem.

This PR simply changes the way that the `code_action` get the line diagnostic.