### PR TITLE
refactor: optimize cursor movement and resource cleanup

### DIFF
--- a/lua/LspUI/hover/init.lua
+++ b/lua/LspUI/hover/init.lua
@@ -38,6 +38,11 @@ function M.deinit()
     end
 
     is_initialized = false
+
+    if hover_manager then
+        hover_manager:Close()
+    end
+
     command.unregister_command(command_key)
 end
 

--- a/lua/LspUI/layer/controller.lua
+++ b/lua/LspUI/layer/controller.lua
@@ -589,6 +589,29 @@ function ClassController:_onCursorMoved()
         return
     end
 
+    -- 如果选中项没有变化，跳过后续重操作
+    local prev = self._current_item
+    if prev and prev.uri == uri then
+        local prev_range = prev.range
+        local same_range = false
+
+        if prev_range == nil and range == nil then
+            same_range = true
+        elseif prev_range and range then
+            same_range = prev_range.start.line == range.start.line
+                and prev_range.start.character == range.start.character
+                and prev_range.finish.line == range.finish.line
+                and prev_range.finish.character == range.finish.character
+        end
+
+        if same_range then
+            if self._virtual_scroll.enabled then
+                self:_checkAndLoadMore()
+            end
+            return
+        end
+    end
+
     -- 设置当前项目，即使没有range（表示是文件路径行）
     self._current_item = {
         uri = uri,
@@ -941,12 +964,8 @@ function ClassController:_appendSubViewData(
 
     -- 添加 extmark
     for _, mark in ipairs(extmarks) do
-        local line_content = api.nvim_buf_get_lines(
-            bufId,
-            mark.line,
-            mark.line + 1,
-            false
-        )[1] or ""
+        local relative_line = mark.line - start_line + 1
+        local line_content = content[relative_line] or ""
         api.nvim_buf_set_extmark(bufId, extmark_ns, mark.line, #line_content, {
             virt_text = { { mark.text, mark.hl_group } },
             virt_text_pos = "eol",

--- a/lua/LspUI/layer/hover.lua
+++ b/lua/LspUI/layer/hover.lua
@@ -14,11 +14,13 @@ local tools = require("LspUI.layer.tools")
 --- @field private _hover_tuples hover_tuple[]
 --- @field private _current_index integer
 --- @field private _enter_lock boolean
+--- @field private _autocmd_group integer|nil
 local ClassHover = {
     _view = nil,
     _hover_tuples = {},
     _current_index = 1,
     _enter_lock = false,
+    _autocmd_group = nil,
 }
 
 ClassHover.__index = ClassHover
@@ -221,9 +223,20 @@ function ClassHover:SetAutoCommands(buffer_id)
         return
     end
 
+    if self._autocmd_group then
+        pcall(api.nvim_del_augroup_by_id, self._autocmd_group)
+        self._autocmd_group = nil
+    end
+
+    self._autocmd_group = api.nvim_create_augroup(
+        "LspUI_hover_" .. tostring(buffer_id),
+        { clear = true }
+    )
+
     api.nvim_create_autocmd(
         { "CursorMoved", "InsertEnter", "BufDelete", "BufLeave" },
         {
+            group = self._autocmd_group,
             buffer = buffer_id,
             callback = function()
                 if not self._enter_lock then
@@ -255,6 +268,11 @@ function ClassHover:Focus()
 end
 
 function ClassHover:Close()
+    if self._autocmd_group then
+        pcall(api.nvim_del_augroup_by_id, self._autocmd_group)
+        self._autocmd_group = nil
+    end
+
     if self:IsValid() then
         self._view:Destroy()
         self._view = nil

--- a/lua/LspUI/layer/main_view.lua
+++ b/lua/LspUI/layer/main_view.lua
@@ -185,6 +185,11 @@ function ClassMainView:SaveKeyMappings(buf_id)
         return self
     end
 
+    -- 仅在首次接管该 buffer 时保存映射，避免高频 maparg 开销
+    if self._keymap_history[buf_id] then
+        return self
+    end
+
     local keybinds = {
         config.options.pos_keybind.main.back,
         config.options.pos_keybind.main.hide_secondary,

--- a/lua/LspUI/layer/source_highlight.lua
+++ b/lua/LspUI/layer/source_highlight.lua
@@ -6,6 +6,7 @@ local M = {}
 local source_ns = api.nvim_create_namespace("LspUI_source_highlight")
 local source_highlight_group =
     api.nvim_create_augroup("LspUI.source_highlight", { clear = true })
+local has_ts_hl, ts_highlighter = pcall(require, "vim.treesitter.highlighter")
 
 -- 缓存已提取的高亮信息，避免重复解析
 -- cache[source_buf][line_num] = { {hl_group, start_col, end_col}, ... }
@@ -54,8 +55,6 @@ function M.extract_line_highlights(source_buf, source_line)
     local highlights = {}
 
     -- 优先尝试使用已有的 highlighter（避免重复解析）
-    local has_ts_hl, ts_highlighter =
-        pcall(require, "vim.treesitter.highlighter")
     if not has_ts_hl then
         return {}
     end

--- a/tests/test_controller.lua
+++ b/tests/test_controller.lua
@@ -1,0 +1,144 @@
+local h = require("tests.helpers")
+local new_set = MiniTest.new_set
+
+local child = MiniTest.new_child_neovim()
+
+local T = new_set({
+    hooks = {
+        pre_case = function()
+            h.child_start(child)
+        end,
+        post_once = child.stop,
+    },
+})
+
+T["controller"] = new_set()
+
+T["controller"]["onCursorMoved short-circuits unchanged selection"] =
+    function()
+        local result = child.lua([[
+            local ClassController = require("LspUI.layer.controller")
+
+            local ctl = setmetatable({}, ClassController)
+            local range = {
+                start = { line = 1, character = 2 },
+                finish = { line = 1, character = 4 },
+            }
+
+            ctl._current_item = {
+                uri = "file:///tmp/a.lua",
+                buffer_id = 1,
+                range = vim.deepcopy(range),
+                is_file_header = false,
+            }
+
+            local heavy_calls = 0
+            local load_more_calls = 0
+
+            ctl._getLspPositionByLnum = function()
+                return "file:///tmp/a.lua", range
+            end
+
+            ctl._checkAndLoadMore = function()
+                load_more_calls = load_more_calls + 1
+            end
+
+            ctl._mainView = {
+                Valid = function() return true end,
+                UnPinBuffer = function() heavy_calls = heavy_calls + 1 end,
+                GetBufID = function() return 1 end,
+                RestoreKeyMappings = function() heavy_calls = heavy_calls + 1 end,
+                SwitchBuffer = function() heavy_calls = heavy_calls + 1 end,
+                SaveKeyMappings = function() heavy_calls = heavy_calls + 1 end,
+                PinBuffer = function() heavy_calls = heavy_calls + 1 end,
+                GetWinID = function() heavy_calls = heavy_calls + 1; return nil end,
+                SetHighlight = function() heavy_calls = heavy_calls + 1 end,
+            }
+
+            ctl._lsp = {
+                GetData = function()
+                    return { ["file:///tmp/a.lua"] = { buffer_id = 1 } }
+                end,
+            }
+
+            ctl._virtual_scroll = { enabled = true }
+
+            ctl:_onCursorMoved()
+
+            return {
+                heavy_calls = heavy_calls,
+                load_more_calls = load_more_calls,
+                uri_unchanged = ctl._current_item.uri == "file:///tmp/a.lua",
+                range_unchanged = ctl._current_item.range.start.line == 1,
+            }
+        ]])
+
+        h.eq(0, result.heavy_calls)
+        h.eq(1, result.load_more_calls)
+        h.eq(true, result.uri_unchanged)
+        h.eq(true, result.range_unchanged)
+    end
+
+T["controller"]["onCursorMoved still updates when selection changes"] =
+    function()
+        local result = child.lua([[
+            local ClassController = require("LspUI.layer.controller")
+
+            local ctl = setmetatable({}, ClassController)
+            local old_range = {
+                start = { line = 1, character = 2 },
+                finish = { line = 1, character = 4 },
+            }
+            local new_range = {
+                start = { line = 2, character = 0 },
+                finish = { line = 2, character = 3 },
+            }
+
+            ctl._current_item = {
+                uri = "file:///tmp/a.lua",
+                buffer_id = 1,
+                range = old_range,
+                is_file_header = false,
+            }
+
+            local heavy_calls = 0
+            ctl._getLspPositionByLnum = function()
+                return "file:///tmp/a.lua", new_range
+            end
+            ctl._setupMainViewKeyBindings = function()
+                heavy_calls = heavy_calls + 1
+            end
+
+            ctl._mainView = {
+                Valid = function() return true end,
+                UnPinBuffer = function() heavy_calls = heavy_calls + 1 end,
+                GetBufID = function() return 1 end,
+                RestoreKeyMappings = function() heavy_calls = heavy_calls + 1 end,
+                SwitchBuffer = function() heavy_calls = heavy_calls + 1 end,
+                SaveKeyMappings = function() heavy_calls = heavy_calls + 1 end,
+                PinBuffer = function() heavy_calls = heavy_calls + 1 end,
+                GetWinID = function() return nil end,
+                SetHighlight = function() heavy_calls = heavy_calls + 1 end,
+            }
+
+            ctl._lsp = {
+                GetData = function()
+                    return { ["file:///tmp/a.lua"] = { buffer_id = 1 } }
+                end,
+            }
+
+            ctl._virtual_scroll = { enabled = false }
+
+            ctl:_onCursorMoved()
+
+            return {
+                heavy_calls = heavy_calls,
+                new_line = ctl._current_item.range.start.line,
+            }
+        ]])
+
+        h.eq(true, result.heavy_calls > 0)
+        h.eq(2, result.new_line)
+    end
+
+return T

--- a/tests/test_controller.lua
+++ b/tests/test_controller.lua
@@ -14,9 +14,8 @@ local T = new_set({
 
 T["controller"] = new_set()
 
-T["controller"]["onCursorMoved short-circuits unchanged selection"] =
-    function()
-        local result = child.lua([[
+T["controller"]["onCursorMoved short-circuits unchanged selection"] = function()
+    local result = child.lua([[
             local ClassController = require("LspUI.layer.controller")
 
             local ctl = setmetatable({}, ClassController)
@@ -73,15 +72,14 @@ T["controller"]["onCursorMoved short-circuits unchanged selection"] =
             }
         ]])
 
-        h.eq(0, result.heavy_calls)
-        h.eq(1, result.load_more_calls)
-        h.eq(true, result.uri_unchanged)
-        h.eq(true, result.range_unchanged)
-    end
+    h.eq(0, result.heavy_calls)
+    h.eq(1, result.load_more_calls)
+    h.eq(true, result.uri_unchanged)
+    h.eq(true, result.range_unchanged)
+end
 
-T["controller"]["onCursorMoved still updates when selection changes"] =
-    function()
-        local result = child.lua([[
+T["controller"]["onCursorMoved still updates when selection changes"] = function()
+    local result = child.lua([[
             local ClassController = require("LspUI.layer.controller")
 
             local ctl = setmetatable({}, ClassController)
@@ -137,8 +135,8 @@ T["controller"]["onCursorMoved still updates when selection changes"] =
             }
         ]])
 
-        h.eq(true, result.heavy_calls > 0)
-        h.eq(2, result.new_line)
-    end
+    h.eq(true, result.heavy_calls > 0)
+    h.eq(2, result.new_line)
+end
 
 return T

--- a/tests/test_hover.lua
+++ b/tests/test_hover.lua
@@ -138,6 +138,46 @@ T["hover module"]["deinit unregisters command"] = function()
     h.eq(false, result.has_command_after)
 end
 
+T["hover module"]["layer hover close cleans autocmd group"] = function()
+    local result = child.lua([[
+        local ClassHover = require("LspUI.layer.hover")
+        local ClassView = require("LspUI.layer.view")
+
+        local hover = ClassHover:New()
+        local view = ClassView:New(true)
+            :Size(20, 3)
+            :Pos(1, 1)
+            :Anchor("NW")
+            :Relative("editor")
+            :Style("minimal")
+            :Render()
+
+        hover._view = view
+        local bufnr = view:GetBufID()
+
+        hover:SetAutoCommands(bufnr)
+        local group_id = hover._autocmd_group
+
+        local before_ok = pcall(vim.api.nvim_get_autocmds, { group = group_id })
+
+        hover:Close()
+
+        local after_ok = pcall(vim.api.nvim_get_autocmds, { group = group_id })
+
+        return {
+            before_ok = before_ok,
+            after_ok = after_ok,
+            group_cleared = hover._autocmd_group == nil,
+            view_closed = not view:Valid(),
+        }
+    ]])
+
+    h.eq(true, result.before_ok)
+    h.eq(false, result.after_ok)
+    h.eq(true, result.group_cleared)
+    h.eq(true, result.view_closed)
+end
+
 T["hover module"]["double init is idempotent"] = function()
     local result = child.lua([[
         local config = require("LspUI.config")


### PR DESCRIPTION
Skip redundant UI updates when selection unchanged and properly clean up autocmd groups and hover resources on deinitialization to prevent memory leaks and resource exhaustion