### PR TITLE
fix(hover): correct markdown link rendering and make gx work

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ require("LspUI").setup({
       prev = "p",
       next = "n",
       quit = "q",
+      open_url = "gx",
     },
     border = "rounded",
     transparency = 0,

--- a/doc/LspUI.txt
+++ b/doc/LspUI.txt
@@ -145,6 +145,7 @@ Full configuration with defaults: >lua
           prev = "p",
           next = "n",
           quit = "q",
+          open_url = "gx",
         },
         border = "rounded",
         transparency = 0,
@@ -402,6 +403,7 @@ Configuration: >lua
         prev = "p",            -- Previous hover
         next = "n",            -- Next hover
         quit = "q",            -- Close hover
+        open_url = "gx",       -- Open the link under the cursor ("" disables)
       },
       border = "rounded",      -- Border style for the hover window
       transparency = 0,        -- Window transparency

--- a/lua/LspUI/_meta.lua
+++ b/lua/LspUI/_meta.lua
@@ -36,7 +36,7 @@
 --- @class LspUI_hover_config
 --- @field enable boolean? whether enable `hover` module
 --- @field command_enable boolean? whether enable command for `hover`
---- @field key_binding { prev: string?, next: string?, quit: string? }? keybind for `hover`
+--- @field key_binding { prev: string?, next: string?, quit: string?, open_url: string? }? keybind for `hover`, `open_url` opens the link under cursor (set to `""` to disable)
 --- @field border "none"|"single"|"double"|"rounded"|"solid"|"shadow"|string[]? border style for hover window
 --- @field transparency number? transparency for hover
 

--- a/lua/LspUI/config.lua
+++ b/lua/LspUI/config.lua
@@ -62,6 +62,7 @@ local default_hover_config = {
         prev = "p",
         next = "n",
         quit = "q",
+        open_url = "gx",
     },
     transparency = default_transparency,
     border = "rounded",

--- a/lua/LspUI/layer/hover.lua
+++ b/lua/LspUI/layer/hover.lua
@@ -15,12 +15,14 @@ local tools = require("LspUI.layer.tools")
 --- @field private _current_index integer
 --- @field private _enter_lock boolean
 --- @field private _autocmd_group integer|nil
+--- @field private _key_bindings table|nil
 local ClassHover = {
     _view = nil,
     _hover_tuples = {},
     _current_index = 1,
     _enter_lock = false,
     _autocmd_group = nil,
+    _key_bindings = nil,
 }
 
 ClassHover.__index = ClassHover
@@ -37,7 +39,12 @@ end
 --- @param winnr integer
 local function apply_treesitter_highlight(bufnr, winnr)
     vim.wo[winnr].conceallevel = 2
-    vim.wo[winnr].concealcursor = "n"
+    -- 与 neovim 原生 hover 保持一致：光标所在行不做 conceal。
+    -- 若设为 "n"，`[text](url)` 的 URL 段在光标行也会被隐藏，
+    -- 用户既看不到链接目标，光标也无法落到被 conceal 的区间上，导致 `gx` 不可用。
+    vim.wo[winnr].concealcursor = ""
+    vim.wo[winnr].foldenable = false
+    vim.wo[winnr].smoothscroll = true
     -- Disable legacy syntax to avoid loading syntax/markdown.vim chain
     -- which may fail if dtd.vim is missing
     vim.bo[bufnr].syntax = ""
@@ -46,28 +53,209 @@ local function apply_treesitter_highlight(bufnr, winnr)
     pcall(vim.treesitter.start, bufnr)
 end
 
+--- 判断是否为 markdown 主题分隔线（GFM thematic break）
+--- @param line string
+--- @return boolean
+local function is_separator_line(line)
+    -- 最多 3 个前导空格，其后为 >=3 个同种 - * _，中间只允许空白
+    local body = line:match("^ ? ? ?([-*_][-*_%s]*)$")
+    if not body then
+        return false
+    end
+    local delim = body:sub(1, 1)
+    local count = 0
+    for char in body:gmatch("%S") do
+        if char ~= delim then
+            return false
+        end
+        count = count + 1
+    end
+    return count >= 3
+end
+
+--- 归一化 LSP 返回的 markdown，行为对齐 vim.lsp.util._normalize_markdown：
+--- 1. 去掉 \r 与首尾空行  2. 连续空行折叠为一行  3. 分隔线展开为等宽横线（并吃掉相邻空行）
+--- @param lines string[]
+--- @param width integer
+--- @return string[]
+local function normalize_markdown(lines, width)
+    local raw = table.concat(lines, "\n"):gsub("\r", "")
+    local source = vim.split(raw, "\n", { trimempty = true })
+    local divider = string.rep("─", width)
+
+    local result = {}
+    local index = 1
+    while index <= #source do
+        local line = source[index]
+        if line:match("^%s*$") then
+            -- 折叠连续空行
+            if #result > 0 and result[#result] ~= "" then
+                result[#result + 1] = ""
+            end
+        elseif is_separator_line(line) then
+            if result[#result] == "" then
+                result[#result] = nil
+            end
+            result[#result + 1] = divider
+            -- 吃掉分隔线后紧跟的空行
+            while source[index + 1] and source[index + 1]:match("^%s*$") do
+                index = index + 1
+            end
+        else
+            result[#result + 1] = line
+        end
+        index = index + 1
+    end
+
+    while #result > 0 and result[#result] == "" do
+        result[#result] = nil
+    end
+    return result
+end
+
 --- Create a hover buffer from markdown lines
 --- @param markdown_lines string[]
 --- @return integer buffer_id
 --- @return integer width
 --- @return integer height
 local function create_hover_buffer(markdown_lines)
-    local new_buffer = api.nvim_create_buf(false, true)
-    api.nvim_buf_set_lines(new_buffer, 0, -1, true, markdown_lines)
-    vim.bo[new_buffer].bufhidden = "wipe"
-    vim.bo[new_buffer].modifiable = false
-
-    -- Calculate dimensions
+    -- 先按原始内容估算宽度，再用该宽度归一化（分隔线需要知道最终宽度）
     local width = 0
     for _, str in ipairs(markdown_lines) do
         width = math.max(width, fn.strdisplaywidth(str))
     end
     width = math.min(width, math.floor(tools.get_max_width() * 0.5))
+    width = math.max(width, 1)
+
+    markdown_lines = normalize_markdown(markdown_lines, width)
+
+    local new_buffer = api.nvim_create_buf(false, true)
+    api.nvim_buf_set_lines(new_buffer, 0, -1, true, markdown_lines)
+    vim.bo[new_buffer].bufhidden = "wipe"
+    vim.bo[new_buffer].modifiable = false
+
     local height =
         math.min(#markdown_lines, math.floor(tools.get_max_height() * 0.6))
 
-    return new_buffer, width, height
+    return new_buffer, width, math.max(height, 1)
 end
+
+--- markdown 中承载链接的节点类型
+local link_node_types = {
+    inline_link = true,
+    image = true,
+    full_reference_link = true,
+    collapsed_reference_link = true,
+    shortcut_link = true,
+    uri_autolink = true,
+    email_autolink = true,
+}
+
+--- 收集 buffer 内的链接引用定义：`[label]: url`
+--- @param bufnr integer
+--- @return table<string, string>
+local function collect_link_refs(bufnr)
+    local refs = {}
+    for _, line in ipairs(api.nvim_buf_get_lines(bufnr, 0, -1, false)) do
+        local label, dest = line:match("^%s*%[([^%]]+)%]:%s*(%S+)")
+        if label then
+            refs[label:lower()] = dest
+        end
+    end
+    return refs
+end
+
+--- 在指定行里找出包含 col 的裸 URL
+--- @param line string
+--- @param col integer 0-based
+--- @return string|nil
+local function find_bare_url(line, col)
+    local init = 1
+    while true do
+        local s, e = line:find("%a[%w+.-]*://[^%s)%]>,\"']+", init)
+        if not s then
+            return nil
+        end
+        if col >= s - 1 and col <= e - 1 then
+            return (line:sub(s, e):gsub("[.,:;!?]+$", ""))
+        end
+        init = e + 1
+    end
+end
+
+--- 解析光标处的链接目标。
+--- 兼容行内链接、图片、autolink，以及 treesitter 未提供 url 元数据的引用式链接。
+--- @param bufnr integer
+--- @param winnr integer
+--- @return string|nil
+local function resolve_url_at_cursor(bufnr, winnr)
+    local cursor = api.nvim_win_get_cursor(winnr)
+    local row, col = cursor[1] - 1, cursor[2]
+
+    -- markdown 的行内内容位于 markdown_inline 注入树中，
+    -- vim.treesitter.get_node 不会下潜到注入树，需要手动取注入树的节点
+    local node = (function()
+        local has_parser, parser =
+            pcall(vim.treesitter.get_parser, bufnr, nil, { error = false })
+        if not has_parser or not parser then
+            return nil
+        end
+        local range = { row, col, row, col }
+        local ok = pcall(parser.parse, parser, { row, row + 1 })
+        if not ok then
+            return nil
+        end
+        local ok_tree, result = pcall(function()
+            local language_tree = parser:language_for_range(range)
+            local tree = language_tree:tree_for_range(range)
+            return tree
+                and tree:root():named_descendant_for_range(row, col, row, col)
+        end)
+        return ok_tree and result or nil
+    end)()
+
+    while node do
+        local node_type = node:type()
+        if link_node_types[node_type] then
+            if node_type == "uri_autolink" or node_type == "email_autolink" then
+                local text = vim.treesitter.get_node_text(node, bufnr)
+                text = text:sub(2, -2) -- 去掉两侧的 < >
+                return node_type == "email_autolink" and ("mailto:" .. text)
+                    or text
+            end
+
+            for child in node:iter_children() do
+                if child:type() == "link_destination" then
+                    return vim.treesitter.get_node_text(child, bufnr)
+                end
+            end
+
+            -- 引用式链接：用 label 去查 `[label]: url`
+            local refs = collect_link_refs(bufnr)
+            for child in node:iter_children() do
+                local child_type = child:type()
+                if child_type == "link_label" or child_type == "link_text" then
+                    local label = vim.treesitter
+                        .get_node_text(child, bufnr)
+                        :gsub("^%[", "")
+                        :gsub("%]$", "")
+                    local url = refs[label:lower()]
+                    if url then
+                        return url
+                    end
+                end
+            end
+        end
+        node = node:parent()
+    end
+
+    local line = api.nvim_buf_get_lines(bufnr, row, row + 1, false)[1]
+    return line and find_bare_url(line, col) or nil
+end
+
+-- 暴露给测试与复用（不依赖实例状态）
+ClassHover.NormalizeMarkdown = normalize_markdown
+ClassHover.ResolveUrlAtCursor = resolve_url_at_cursor
 
 --- @param buffer_id integer
 --- @return vim.lsp.Client[]|nil
@@ -164,10 +352,28 @@ function ClassHover:Render(hover_tuple, total, options)
     local winnr = view:GetWinID()
     if winnr then
         apply_treesitter_highlight(hover_tuple.buffer_id, winnr)
+        self:FitHeight(hover_tuple)
     end
 
     self._view = view
     return view
+end
+
+--- 按 treesitter conceal / wrap 之后的真实文本高度调整窗口高度，
+--- 避免代码块反引号被 conceal 后留下空行，或长行折行后内容被截断。
+--- @param hover_tuple hover_tuple
+function ClassHover:FitHeight(hover_tuple)
+    local winnr = self._view and self._view:GetWinID()
+    if not winnr then
+        return
+    end
+    local max_height = math.max(1, math.floor(tools.get_max_height() * 0.6))
+    local ok, result =
+        pcall(api.nvim_win_text_height, winnr, { max_height = max_height })
+    if ok and result.all > 0 then
+        hover_tuple.height = math.min(result.all, max_height)
+        self._view:Size(hover_tuple.width, hover_tuple.height)
+    end
 end
 
 --- @param forward boolean
@@ -189,6 +395,7 @@ function ClassHover:NextRender(forward)
     local winnr = self._view:GetWinID()
     if winnr then
         apply_treesitter_highlight(hover_tuple.buffer_id, winnr)
+        self:FitHeight(hover_tuple)
     end
 
     local title = string.format("hover[%d/%d]", self._current_index, total)
@@ -196,13 +403,20 @@ function ClassHover:NextRender(forward)
         self._view:Size(hover_tuple.width, hover_tuple.height)
         self._view:Title(title, "right")
     end)
+
+    -- keymap 是 buffer 局部的，切换 buffer 后需要重新绑定
+    if self._key_bindings then
+        self:SetKeyBindings(self._key_bindings)
+    end
 end
 
---- @param key_bindings { next: string, prev: string, quit: string }
+--- @param key_bindings { next: string, prev: string, quit: string, open_url: string? }
 function ClassHover:SetKeyBindings(key_bindings)
     if not self._view then
         return
     end
+
+    self._key_bindings = key_bindings
 
     self._view:KeyMap("n", key_bindings.next, function()
         self:NextRender(true)
@@ -215,6 +429,38 @@ function ClassHover:SetKeyBindings(key_bindings)
     self._view:KeyMap("n", key_bindings.quit, function()
         self:Close()
     end, "close hover")
+
+    if key_bindings.open_url and key_bindings.open_url ~= "" then
+        self._view:KeyMap("n", key_bindings.open_url, function()
+            self:OpenUrl()
+        end, "open url under cursor")
+    end
+end
+
+--- 打开光标下的链接。
+--- 不走默认 `gx`：默认实现依赖 treesitter 的 url 元数据，对引用式链接会拿到
+--- 链接文字而不是 URL，且找不到目标时会抛 E446。
+function ClassHover:OpenUrl()
+    if not self:IsValid() then
+        return
+    end
+
+    local buffer_id = self._view:GetBufID()
+    local winnr = self._view:GetWinID()
+    if not buffer_id or not winnr then
+        return
+    end
+
+    local url = resolve_url_at_cursor(buffer_id, winnr)
+    if not url then
+        notify.Info("no url under cursor!")
+        return
+    end
+
+    local ok, err = vim.ui.open(url)
+    if not ok then
+        notify.Warn(err or string.format("failed to open %s", url))
+    end
 end
 
 --- @param buffer_id integer
@@ -296,6 +542,7 @@ function ClassHover:Close()
     end
     self._hover_tuples = {}
     self._current_index = 1
+    self._key_bindings = nil
 end
 
 return ClassHover

--- a/tests/test_hover.lua
+++ b/tests/test_hover.lua
@@ -237,6 +237,26 @@ T["hover config"]["respects custom border"] = function()
     h.eq("single", result)
 end
 
+T["hover config"]["open_url defaults to gx"] = function()
+    local result = child.lua([[
+        local config = require("LspUI.config")
+        config.setup({})
+        return config.options.hover.key_binding.open_url
+    ]])
+    h.eq("gx", result)
+end
+
+T["hover config"]["respects custom open_url"] = function()
+    local result = child.lua([[
+        local config = require("LspUI.config")
+        config.setup({ hover = { key_binding = { open_url = "<cr>" } } })
+        return config.options.hover.key_binding
+    ]])
+    h.eq("<cr>", result.open_url)
+    -- 未覆盖的键仍保留默认值
+    h.eq("q", result.quit)
+end
+
 T["hover config"]["respects transparency setting"] = function()
     local result = child.lua([[
         local config = require("LspUI.config")
@@ -245,6 +265,89 @@ T["hover config"]["respects transparency setting"] = function()
         return config.options.hover.transparency
     ]])
     h.eq(20, result)
+end
+
+T["hover markdown"] = new_set()
+
+T["hover markdown"]["normalizes lsp markdown like neovim native"] = function()
+    local result = child.lua([[
+        local ClassHover = require("LspUI.layer.hover")
+        local input = vim.lsp.util.convert_input_to_markdown_lines({
+            kind = "markdown",
+            value = table.concat({
+                "",
+                "doc line",
+                "",
+                "",
+                "",
+                "---",
+                "",
+                "after",
+                "",
+                "",
+            }, "\r\n"),
+        })
+        return ClassHover.NormalizeMarkdown(input, 5)
+    ]])
+    h.eq({ "doc line", "─────", "after" }, result)
+end
+
+T["hover markdown"]["resolves url for every link form"] = function()
+    local result = child.lua([[
+        local ClassHover = require("LspUI.layer.hover")
+        local lines = {
+            "See [label](https://example.com/inline) here",
+            "Ref: [ref text][1] and [shortcut] end",
+            "Auto: <https://example.com/auto>",
+            "Bare: https://example.com/bare end",
+            "Mail: <foo@bar.com>",
+            "plain text without any link",
+            "",
+            "[1]: https://example.com/ref",
+            "[shortcut]: https://example.com/shortcut",
+        }
+        local buffer_id = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_buf_set_lines(buffer_id, 0, -1, true, lines)
+        vim.bo[buffer_id].filetype = "markdown"
+        local window_id = vim.api.nvim_open_win(buffer_id, true, {
+            relative = "editor",
+            row = 1,
+            col = 1,
+            width = 60,
+            height = 10,
+            style = "minimal",
+        })
+
+        -- { 行号, 0-based 列 }
+        local cursors = {
+            inline_label = { 1, 6 },
+            inline_url = { 1, 20 },
+            full_reference = { 2, 7 },
+            shortcut = { 2, 25 },
+            autolink = { 3, 10 },
+            bare = { 4, 10 },
+            email = { 5, 8 },
+            plain = { 6, 3 },
+        }
+        local resolved = {}
+        for name, pos in pairs(cursors) do
+            vim.api.nvim_win_set_cursor(window_id, { pos[1], pos[2] })
+            resolved[name] = ClassHover.ResolveUrlAtCursor(buffer_id, window_id)
+                or "none"
+        end
+
+        vim.api.nvim_win_close(window_id, true)
+        return resolved
+    ]])
+
+    h.eq("https://example.com/inline", result.inline_label)
+    h.eq("https://example.com/inline", result.inline_url)
+    h.eq("https://example.com/ref", result.full_reference)
+    h.eq("https://example.com/shortcut", result.shortcut)
+    h.eq("https://example.com/auto", result.autolink)
+    h.eq("https://example.com/bare", result.bare)
+    h.eq("mailto:foo@bar.com", result.email)
+    h.eq("none", result.plain)
 end
 
 return T


### PR DESCRIPTION
## Problem

Markdown hyperlinks in the hover window rendered incorrectly and `gx` could not follow them. Comparing against native `vim.lsp.util.open_floating_preview` showed three overlapping causes.

### 1. `concealcursor = "n"` hides the URL

Neovim's bundled `queries/markdown_inline/highlights.scm` conceals `[`, `]`, `(`, `link_destination` and `)` of an `inline_link`. Native hover uses `concealcursor = ""` so the cursor line is not concealed; we used `"n"`, which keeps the cursor line concealed too:

```
concealcursor='n'  ->  See pkg.go.dev for docs.                       <- URL invisible
concealcursor=''   ->  See [pkg.go.dev](https://pkg.go.dev/fmt#Println) for docs.
```

Once the URL is concealed the cursor cannot land on it, so the link looks like plain text and only the few columns of the link label are targetable.

### 2. The default `gx` is unreliable here

The default `gx` relies on the `url` metadata set by the treesitter highlight query, which only covers `inline_link`, `image` and `uri_autolink`:

| Cursor on | `gx` before |
|---|---|
| `[ref text][1]` | opens `text` (reference links yield the link label) |
| `[shortcut]` | opens `shortcut` |
| `<foo@bar.com>` | nothing |
| plain text | throws `E446: No file name under cursor` |

### 3. No markdown normalization or height fitting

Native runs `_normalize_markdown` (strip `\r`, collapse blank lines, expand `---` to a full-width divider) and shrinks the window to the real text height after conceal. We did neither.

## Changes

`lua/LspUI/layer/hover.lua`:

- `concealcursor = ""`, plus `foldenable = false` and `smoothscroll = true`, matching native hover
- New `normalize_markdown()`, matching the behaviour of `vim.lsp.util._normalize_markdown` without depending on the private API
- New `FitHeight()`, using `nvim_win_text_height` to size the window to the real height after conceal and soft wrapping, so concealed code fence backticks no longer leave blank lines
- New `resolve_url_at_cursor()` + `OpenUrl()`, bound to `gx` inside the hover window. It walks the markdown_inline **injection tree** (`language_for_range` -> `tree_for_range` -> `named_descendant_for_range`; `vim.treesitter.get_node` does not descend into injections and only returns the `inline` node), covering inline links, images, autolinks, emails and reference links (scanning `[label]: url` definitions to fill in the mapping the bundled query lacks), with a bare URL scan of the cursor line as a fallback. When nothing is found it reports via `notify.Info` instead of throwing `E446`
- Also fixes a pre-existing bug: keymaps are buffer-local, so with multiple clients `NextRender` switching buffers dropped `n` / `p` / `q`. They are now re-applied after the switch

New config option `hover.key_binding.open_url` (default `"gx"`, set `""` to disable), with `_meta.lua`, `README.md` and `doc/LspUI.txt` updated.

## Verification

Driving the full path with an in-process fake LSP server (`LspUI.api.hover()` -> float -> actually pressing `gx`):

```
inline_link(label)   -> https://pkg.go.dev/fmt#Println
inline_link(url)     -> https://pkg.go.dev/fmt#Println
full_reference_link  -> https://example.com/ref          (before: "text")
shortcut_link        -> https://example.com/shortcut     (before: "shortcut")
uri_autolink         -> https://example.com/auto
bare url             -> https://example.com/bare
email_autolink       -> mailto:foo@bar.com               (before: nothing)
plain text           -> no url under cursor              (before: E446)
```

The normalized buffer content also matches native (blank lines collapsed, `---` -> `────`).

Tests: the existing 248 cases plus 4 new ones (`open_url` default and config merging, `NormalizeMarkdown`, `ResolveUrlAtCursor` across every link form) all pass. All of them are internal integration tests that need no real LSP server.
