### PR TITLE
perf: eliminate autocmd-chain costs in hover and reference views

### DIFF
--- a/lua/LspUI/layer/hover.lua
+++ b/lua/LspUI/layer/hover.lua
@@ -45,10 +45,17 @@ local function apply_treesitter_highlight(bufnr, winnr)
     vim.wo[winnr].concealcursor = ""
     vim.wo[winnr].foldenable = false
     vim.wo[winnr].smoothscroll = true
-    -- Disable legacy syntax to avoid loading syntax/markdown.vim chain
-    -- which may fail if dtd.vim is missing
-    vim.bo[bufnr].syntax = ""
-    vim.bo[bufnr].filetype = "markdown"
+    -- 设置 filetype 会触发 syntaxset 链去加载 syntax/markdown.vim（连带 html.vim 等），
+    -- 而 hover 完全靠 treesitter 高亮，这份开销纯属浪费：实测占单次渲染 95% 以上。
+    -- 临时把 Syntax 加进 eventignore，只跳过 legacy syntax 加载；
+    -- FileType 事件照常触发，render-markdown.nvim 之类依赖 ft 的集成不受影响。
+    local saved_eventignore = vim.o.eventignore
+    vim.o.eventignore = saved_eventignore == "" and "Syntax"
+        or (saved_eventignore .. ",Syntax")
+    pcall(function()
+        vim.bo[bufnr].filetype = "markdown"
+    end)
+    vim.o.eventignore = saved_eventignore
     -- Use treesitter only for highlighting
     pcall(vim.treesitter.start, bufnr)
 end

--- a/lua/LspUI/layer/source_highlight.lua
+++ b/lua/LspUI/layer/source_highlight.lua
@@ -185,6 +185,160 @@ function M.extract_line_highlights(source_buf, source_line)
     return highlights
 end
 
+--- 基于纯文本提取 Treesitter 高亮（用于源文件未加载的场景）。
+--- 用 get_string_parser 解析单行代码，完全不需要 bufload 源文件，
+--- 因此不会触发 BufRead/FileType 自动命令链（LSP attach、gitsigns 等）。
+--- @param lang string treesitter 语言名（即 filetype）
+--- @param text string 单行代码文本
+--- @return table[] 高亮信息数组，每项为 {hl_group, start_col, end_col, priority}
+local text_cache = {}
+local text_cache_size = 0
+
+function M.extract_text_highlights(lang, text)
+    if lang == "" or text == "" then
+        return {}
+    end
+
+    local key = lang .. "\0" .. text
+    local cached = text_cache[key]
+    if cached then
+        return cached
+    end
+
+    local highlights = {}
+
+    local lang_ok = pcall(vim.treesitter.language.add, lang)
+    if not lang_ok then
+        return highlights
+    end
+    local query_ok, query = pcall(vim.treesitter.query.get, lang, "highlights")
+    if not query_ok or not query then
+        return highlights
+    end
+
+    local parser_ok, parser =
+        pcall(vim.treesitter.get_string_parser, text, lang)
+    if not parser_ok or not parser then
+        return highlights
+    end
+    local parse_ok, trees = pcall(parser.parse, parser, true)
+    if not parse_ok or not trees or #trees == 0 then
+        return highlights
+    end
+
+    for _, tree in ipairs(trees) do
+        local root = tree:root()
+        if root then
+            local iter_ok, iter =
+                pcall(query.iter_captures, query, root, text, 0, 1)
+            if iter_ok then
+                for id, node, metadata in iter do
+                    local range_ok, start_row, start_col, _, end_col =
+                        pcall(node.range, node)
+                    local capture_name = query.captures[id]
+                    if
+                        range_ok
+                        and capture_name
+                        and start_row == 0
+                        and start_col < end_col
+                    then
+                        local priority = 100
+                        if
+                            type(metadata) == "table"
+                            and type(metadata.priority) == "number"
+                        then
+                            priority = metadata.priority
+                        end
+                        table.insert(highlights, {
+                            hl_group = "@" .. capture_name,
+                            start_col = start_col,
+                            end_col = math.min(end_col, #text),
+                            priority = priority,
+                        })
+                    end
+                end
+            end
+        end
+    end
+
+    table.sort(highlights, function(a, b)
+        if a.priority ~= b.priority then
+            return a.priority < b.priority
+        end
+        return a.start_col < b.start_col
+    end)
+
+    -- 有界缓存：引用列表里大量重复的行（同一符号的多处引用）直接命中
+    if text_cache_size > 2000 then
+        text_cache = {}
+        text_cache_size = 0
+    end
+    text_cache[key] = highlights
+    text_cache_size = text_cache_size + 1
+
+    return highlights
+end
+
+--- 用字符串 parser 高亮目标 buffer 里的一段代码（源文件未加载时的替代路径）。
+--- 直接解析目标行 [col_start, col_end) 里显示的文本，无需源 buffer。
+--- @param target_buf integer
+--- @param target_line integer 0-indexed
+--- @param target_col_start integer 0-indexed 起始列
+--- @param target_col_end integer 结束位置（字符串长度语义，同 apply_highlights）
+--- @param lang string
+--- @return boolean 是否成功应用了 treesitter 高亮
+function M.apply_text_highlights(
+    target_buf,
+    target_line,
+    target_col_start,
+    target_col_end,
+    lang
+)
+    local line_ok, target_lines = pcall(
+        api.nvim_buf_get_lines,
+        target_buf,
+        target_line,
+        target_line + 1,
+        false
+    )
+    if not line_ok or not target_lines or not target_lines[1] then
+        return false
+    end
+    local line_text = target_lines[1]
+    local actual_end = math.min(target_col_end, #line_text)
+    if target_col_start >= actual_end then
+        return false
+    end
+
+    local text = line_text:sub(target_col_start + 1, actual_end)
+    local highlights = M.extract_text_highlights(lang, text)
+    if #highlights == 0 then
+        return false
+    end
+
+    for _, hl in ipairs(highlights) do
+        local col_start = target_col_start + hl.start_col
+        local col_end = math.min(target_col_start + hl.end_col, actual_end)
+        if col_start < col_end then
+            pcall(
+                api.nvim_buf_set_extmark,
+                target_buf,
+                source_ns,
+                target_line,
+                col_start,
+                {
+                    end_col = col_end,
+                    hl_group = hl.hl_group,
+                    priority = hl.priority + 10,
+                    strict = false,
+                }
+            )
+        end
+    end
+
+    return true
+end
+
 --- 应用提取的高亮到目标 buffer 的指定区域
 --- @param target_buf integer 目标 buffer ID
 --- @param target_line integer 目标行号（0-indexed）

--- a/lua/LspUI/layer/sub_view.lua
+++ b/lua/LspUI/layer/sub_view.lua
@@ -126,7 +126,7 @@ function ClassSubView:ApplySyntaxHighlight(code_regions)
 
     -- 第一遍：处理所有条目，区分已加载和未加载
     local lang_keyword_regions = {} -- 未加载文件的关键字高亮
-    local pending_sources = {} -- 按源 buffer 分组的待处理条目
+    local pending_text = {} -- 源文件未加载、待用字符串 parser 高亮的条目
 
     for lang, entries in pairs(code_regions) do
         if lang and lang ~= "" then
@@ -168,21 +168,13 @@ function ClassSubView:ApplySyntaxHighlight(code_regions)
                                 end
                             end
                         else
-                            -- 源 buffer 未加载，记录下来稍后异步处理
-                            local source_buf = entry.source_buf
-                            if source_buf then
-                                if not pending_sources[source_buf] then
-                                    pending_sources[source_buf] =
-                                        { entries = {} }
-                                end
-                                table.insert(
-                                    pending_sources[source_buf].entries,
-                                    {
-                                        entry = entry,
-                                        lang = lang,
-                                    }
-                                )
-                            end
+                            -- 源 buffer 未加载：不 bufload（会触发 BufRead/
+                            -- FileType 链，连带 LSP attach 等），改为稍后用
+                            -- 字符串 parser 直接解析该行显示的文本
+                            table.insert(pending_text, {
+                                entry = entry,
+                                lang = lang,
+                            })
                         end
                     end
 
@@ -215,47 +207,31 @@ function ClassSubView:ApplySyntaxHighlight(code_regions)
         end
     end
 
-    -- 异步加载未加载的源文件并应用 Treesitter 高亮
-    if not vim.tbl_isempty(pending_sources) then
+    -- 首帧之后再为未加载的源文件补 Treesitter 高亮：
+    -- 用字符串 parser 解析子视图里已经显示的行文本，全程不加载源 buffer
+    if #pending_text > 0 then
         vim.schedule(function()
-            -- 再次检查 buffer 是否仍然有效
             if not api.nvim_buf_is_valid(bufid) then
                 return
             end
 
-            for source_buf, pack in pairs(pending_sources) do
-                if api.nvim_buf_is_valid(source_buf) then
-                    -- 异步加载源文件（仅执行一次）
-                    if not api.nvim_buf_is_loaded(source_buf) then
-                        pcall(vim.fn.bufload, source_buf)
-                    end
-
-                    if api.nvim_buf_is_loaded(source_buf) then
-                        for _, item in ipairs(pack.entries) do
-                            local entry = item.entry
-                            local lang = item.lang
-                            local source_offset = entry.source_col_offset or 0
-                            local line_map = self._active_keyword_lines[lang]
-                            if line_map and line_map[entry.line] then
-                                keyword_highlight.clear_line(
-                                    bufid,
-                                    lang,
-                                    entry.line
-                                )
-                                line_map[entry.line] = nil
-                                if vim.tbl_isempty(line_map) then
-                                    self._active_keyword_lines[lang] = nil
-                                end
-                            end
-                            source_highlight.apply_highlights(
-                                bufid,
-                                entry.line,
-                                entry.col_start,
-                                entry.col_end,
-                                source_buf,
-                                entry.source_line,
-                                source_offset
-                            )
+            for _, item in ipairs(pending_text) do
+                local entry = item.entry
+                local lang = item.lang
+                local applied = source_highlight.apply_text_highlights(
+                    bufid,
+                    entry.line,
+                    entry.col_start,
+                    entry.col_end,
+                    lang
+                )
+                if applied then
+                    local line_map = self._active_keyword_lines[lang]
+                    if line_map and line_map[entry.line] then
+                        keyword_highlight.clear_line(bufid, lang, entry.line)
+                        line_map[entry.line] = nil
+                        if vim.tbl_isempty(line_map) then
+                            self._active_keyword_lines[lang] = nil
                         end
                     end
                 end

--- a/lua/LspUI/layer/tools.lua
+++ b/lua/LspUI/layer/tools.lua
@@ -5,25 +5,46 @@ local M = {}
 
 local version = "v3"
 
+--- 从磁盘按需读取指定行（0-indexed），读到最大行号即停。
+--- 不经过 bufload：加载 buffer 会触发 BufReadPre/BufReadPost/FileType/Syntax
+--- 整条自动命令链（LSP attach、gitsigns 等），对"只为取几行文本"来说纯属浪费。
+--- @param file_path string
+--- @param sorted_rows integer[] 升序 0-indexed 行号
+--- @param lines table<integer, string> 输出表，按行号填充
+--- @return boolean ok 文件是否成功读取
+local function read_lines_from_disk(file_path, sorted_rows, lines)
+    local file = io.open(file_path, "r")
+    if not file then
+        return false
+    end
+
+    local want = {}
+    for _, row in ipairs(sorted_rows) do
+        want[row] = true
+    end
+    local max_row = sorted_rows[#sorted_rows]
+
+    local row = 0
+    for line in file:lines() do
+        if want[row] then
+            -- CRLF 文件去掉行尾 \r，对齐 buffer 读取的行为
+            lines[row] = (line:gsub("\r$", ""))
+        end
+        if row >= max_row then
+            break
+        end
+        row = row + 1
+    end
+    file:close()
+    return true
+end
+
 --- @param buffer_id integer
 --- @param uri lsp.URI
 --- @param rows integer[]
 --- @return string[]
 function M.GetUriLines(buffer_id, uri, rows)
     local lines = {}
-
-    -- 统一使用 bufload + nvim_buf_get_lines，避免手动文件 IO
-    if not api.nvim_buf_is_valid(buffer_id) then
-        return lines
-    end
-
-    -- 确保 buffer 已加载
-    if not api.nvim_buf_is_loaded(buffer_id) then
-        local ok = pcall(fn.bufload, buffer_id)
-        if not ok then
-            return lines
-        end
-    end
 
     if type(rows) ~= "table" or #rows == 0 then
         return lines
@@ -46,7 +67,24 @@ function M.GetUriLines(buffer_id, uri, rows)
 
     table.sort(sorted_rows)
 
-    -- 2. 将连续的行号合并为区间，避免一次性读取大跨度
+    -- 2. buffer 未加载时直接读磁盘，避免 bufload 触发整条自动命令链
+    local loaded = api.nvim_buf_is_valid(buffer_id)
+        and api.nvim_buf_is_loaded(buffer_id)
+    if not loaded then
+        local ok, file_path = pcall(vim.uri_to_fname, uri)
+        if ok and read_lines_from_disk(file_path, sorted_rows, lines) then
+            return lines
+        end
+        -- 磁盘读取失败（非 file:// URI 等）：退回 bufload 路径
+        if not api.nvim_buf_is_valid(buffer_id) then
+            return lines
+        end
+        if not pcall(fn.bufload, buffer_id) then
+            return lines
+        end
+    end
+
+    -- 3. 将连续的行号合并为区间，避免一次性读取大跨度
     local segments = {}
     local seg_start = sorted_rows[1]
     local seg_end = seg_start
@@ -63,7 +101,7 @@ function M.GetUriLines(buffer_id, uri, rows)
     end
     table.insert(segments, { seg_start, seg_end })
 
-    -- 3. 分段读取，避免跨越巨大范围
+    -- 4. 分段读取，避免跨越巨大范围
     for _, segment in ipairs(segments) do
         local start_row = segment[1]
         local end_row = segment[2]
@@ -266,7 +304,16 @@ end
 --- 检测文件 filetype；先用 vim.filetype.match，失败时回退到扩展名映射
 --- @param file_path string 文件名（相对/绝对路径均可）
 --- @return string filetype 找不到时返回空串
+-- detect_filetype 结果缓存：同一路径在一次渲染里会被反复查询，
+-- vim.filetype.match 单次 ~0.03ms，路径到 filetype 的映射不会变化
+local filetype_cache = {}
+
 function M.detect_filetype(file_path)
+    local cached = filetype_cache[file_path]
+    if cached ~= nil then
+        return cached
+    end
+
     local filetype = vim.filetype.match({ filename = file_path }) or ""
 
     if not filetype or filetype == "" then
@@ -283,6 +330,7 @@ function M.detect_filetype(file_path)
         filetype = ext_map[ext] or ""
     end
 
+    filetype_cache[file_path] = filetype
     return filetype
 end
 

--- a/tests/test_hover.lua
+++ b/tests/test_hover.lua
@@ -292,6 +292,42 @@ T["hover markdown"]["normalizes lsp markdown like neovim native"] = function()
     h.eq({ "doc line", "─────", "after" }, result)
 end
 
+T["hover markdown"]["render keeps filetype and restores eventignore"] = function()
+    local result = child.lua([[
+        require("LspUI.config").setup({})
+        local ClassHover = require("LspUI.layer.hover")
+
+        -- 用户原有的 eventignore 必须被原样还原
+        vim.o.eventignore = "CursorHold"
+
+        local buffer_id = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_buf_set_lines(buffer_id, 0, -1, true, {
+            "# doc",
+            "see [label](https://example.com) here",
+        })
+
+        local hover = ClassHover:New()
+        hover:Render({ buffer_id = buffer_id, width = 40, height = 2 }, 1, {})
+        local window_id = hover._view:GetWinID()
+
+        local out = {
+            eventignore = vim.o.eventignore,
+            filetype = vim.bo[buffer_id].filetype,
+            ts_active = vim.treesitter.highlighter.active[buffer_id] ~= nil,
+            conceallevel = vim.wo[window_id].conceallevel,
+            concealcursor = vim.wo[window_id].concealcursor,
+        }
+        hover:Close()
+        return out
+    ]])
+
+    h.eq("CursorHold", result.eventignore)
+    h.eq("markdown", result.filetype)
+    h.eq(true, result.ts_active)
+    h.eq(2, result.conceallevel)
+    h.eq("", result.concealcursor)
+end
+
 T["hover markdown"]["resolves url for every link form"] = function()
     local result = child.lua([[
         local ClassHover = require("LspUI.layer.hover")

--- a/tests/test_source_highlight.lua
+++ b/tests/test_source_highlight.lua
@@ -1,0 +1,249 @@
+local h = require("tests.helpers")
+local new_set = MiniTest.new_set
+
+local child = MiniTest.new_child_neovim()
+
+local T = new_set({
+    hooks = {
+        pre_case = function()
+            h.child_start(child)
+        end,
+        post_once = child.stop,
+    },
+})
+
+T["extract_text_highlights"] = new_set()
+
+T["extract_text_highlights"]["extracts highlights from lua code"] = function()
+    local result = child.lua([[
+        local sh = require("LspUI.layer.source_highlight")
+        local text = "local function foo(a, b) return a + b end"
+        local highlights = sh.extract_text_highlights("lua", text)
+
+        local ok = #highlights > 0
+        local all_valid = true
+        for _, hl in ipairs(highlights) do
+            if
+                not hl.hl_group:match("^@")
+                or hl.start_col < 0
+                or hl.end_col > #text
+                or hl.start_col >= hl.end_col
+            then
+                all_valid = false
+            end
+        end
+        return { count = #highlights, ok = ok, all_valid = all_valid }
+    ]])
+    h.expect_truthy(result.ok)
+    h.eq(true, result.all_valid)
+end
+
+T["extract_text_highlights"]["returns empty for unknown language"] = function()
+    local result = child.lua([[
+        local sh = require("LspUI.layer.source_highlight")
+        return #sh.extract_text_highlights(
+            "no_such_language_xyz",
+            "local a = 1"
+        )
+    ]])
+    h.eq(0, result)
+end
+
+T["extract_text_highlights"]["returns empty for empty input"] = function()
+    local result = child.lua([[
+        local sh = require("LspUI.layer.source_highlight")
+        return {
+            empty_text = #sh.extract_text_highlights("lua", ""),
+            empty_lang = #sh.extract_text_highlights("", "local a = 1"),
+        }
+    ]])
+    h.eq(0, result.empty_text)
+    h.eq(0, result.empty_lang)
+end
+
+T["extract_text_highlights"]["cache returns identical results"] = function()
+    local result = child.lua([[
+        local sh = require("LspUI.layer.source_highlight")
+        local text = "local cached = require('mod')"
+        local first = sh.extract_text_highlights("lua", text)
+        local second = sh.extract_text_highlights("lua", text)
+        return {
+            same_table = first == second,
+            equal = vim.deep_equal(first, second),
+        }
+    ]])
+    -- 命中缓存应返回同一张表
+    h.eq(true, result.same_table)
+    h.eq(true, result.equal)
+end
+
+T["apply_text_highlights"] = new_set()
+
+T["apply_text_highlights"]["places extmarks offset by col_start"] = function()
+    local result = child.lua([[
+        local sh = require("LspUI.layer.source_highlight")
+        local buf = vim.api.nvim_create_buf(false, true)
+        local line = "   local x = call(1)"
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { line })
+
+        local ok = sh.apply_text_highlights(buf, 0, 3, #line, "lua")
+        local marks =
+            vim.api.nvim_buf_get_extmarks(buf, -1, 0, -1, { details = true })
+
+        local min_col = math.huge
+        local groups_ok = true
+        for _, mark in ipairs(marks) do
+            min_col = math.min(min_col, mark[3])
+            if not mark[4].hl_group:match("^@") then
+                groups_ok = false
+            end
+        end
+        return {
+            ok = ok,
+            count = #marks,
+            min_col = min_col,
+            groups_ok = groups_ok,
+        }
+    ]])
+    h.eq(true, result.ok)
+    h.expect_truthy(result.count > 0)
+    -- 所有 extmark 都不能落进 3 列前缀区
+    h.expect_truthy(result.min_col >= 3)
+    h.eq(true, result.groups_ok)
+end
+
+T["apply_text_highlights"]["returns false when range is invalid"] = function()
+    local result = child.lua([[
+        local sh = require("LspUI.layer.source_highlight")
+        local buf = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { "abc" })
+        return {
+            -- col_start 超过行长
+            beyond = sh.apply_text_highlights(buf, 0, 10, 20, "lua"),
+            -- 未知语言
+            unknown = sh.apply_text_highlights(
+                buf,
+                0,
+                0,
+                3,
+                "no_such_language_xyz"
+            ),
+            -- 行不存在
+            no_line = sh.apply_text_highlights(buf, 5, 0, 3, "lua"),
+        }
+    ]])
+    h.eq(false, result.beyond)
+    h.eq(false, result.unknown)
+    h.eq(false, result.no_line)
+end
+
+T["sub_view pending highlight"] = new_set()
+
+T["sub_view pending highlight"]["highlights unloaded source without bufload"] = function()
+    local result = child.lua([[
+        local ClassSubView = require("LspUI.layer.sub_view")
+
+        -- 磁盘上的"源文件"，只 bufadd 不加载
+        local path = vim.fn.tempname() .. ".lua"
+        local file = io.open(path, "w")
+        file:write("local value = compute(42)\n")
+        file:close()
+        local source_buf = vim.fn.bufadd(path)
+
+        local fired = 0
+        vim.api.nvim_create_autocmd(
+            { "BufReadPre", "BufReadPost", "FileType", "Syntax" },
+            { callback = function() fired = fired + 1 end }
+        )
+
+        local sub = ClassSubView:New(true)
+        local bufid = sub:GetBufID()
+        local code_line = "   local value = compute(42)"
+        vim.api.nvim_buf_set_lines(bufid, 0, -1, false, { code_line })
+
+        sub:ApplySyntaxHighlight({
+            lua = {
+                {
+                    line = 0,
+                    col_start = 3,
+                    col_end = #code_line,
+                    source_buf = source_buf,
+                    source_line = 0,
+                    source_col_offset = 0,
+                },
+            },
+        })
+
+        -- 高亮在 vim.schedule 之后补上
+        vim.wait(500, function()
+            local marks = vim.api.nvim_buf_get_extmarks(bufid, -1, 0, -1, {})
+            return #marks > 0
+        end)
+
+        local marks =
+            vim.api.nvim_buf_get_extmarks(bufid, -1, 0, -1, { details = true })
+        local has_ts_group = false
+        for _, mark in ipairs(marks) do
+            if
+                mark[4].hl_group and tostring(mark[4].hl_group):match("^@")
+            then
+                has_ts_group = true
+            end
+        end
+
+        local out = {
+            marks = #marks,
+            has_ts_group = has_ts_group,
+            source_loaded = vim.api.nvim_buf_is_loaded(source_buf),
+            fired = fired,
+        }
+        vim.fn.delete(path)
+        return out
+    ]])
+    h.expect_truthy(result.marks > 0)
+    h.eq(true, result.has_ts_group)
+    -- 核心断言：源文件全程未被加载、未触发任何自动命令链
+    h.eq(false, result.source_loaded)
+    h.eq(0, result.fired)
+end
+
+T["sub_view pending highlight"]["loaded source still uses buffer path"] = function()
+    local result = child.lua([[
+        local ClassSubView = require("LspUI.layer.sub_view")
+
+        local path = vim.fn.tempname() .. ".lua"
+        local file = io.open(path, "w")
+        file:write("local ready = true\n")
+        file:close()
+        local source_buf = vim.fn.bufadd(path)
+        vim.fn.bufload(source_buf)
+        vim.bo[source_buf].filetype = "lua"
+
+        local sub = ClassSubView:New(true)
+        local bufid = sub:GetBufID()
+        local code_line = "   local ready = true"
+        vim.api.nvim_buf_set_lines(bufid, 0, -1, false, { code_line })
+
+        sub:ApplySyntaxHighlight({
+            lua = {
+                {
+                    line = 0,
+                    col_start = 3,
+                    col_end = #code_line,
+                    source_buf = source_buf,
+                    source_line = 0,
+                    source_col_offset = 0,
+                },
+            },
+        })
+
+        -- 已加载路径是同步的
+        local marks = vim.api.nvim_buf_get_extmarks(bufid, -1, 0, -1, {})
+        local out = { marks = #marks }
+        vim.fn.delete(path)
+        return out
+    ]])
+    h.expect_truthy(result.marks > 0)
+end
+
+return T

--- a/tests/test_tools.lua
+++ b/tests/test_tools.lua
@@ -343,6 +343,156 @@ T["GetUriLines"]["returns lines for valid buffer"] = function()
     h.eq("line3", result.line2)
 end
 
+T["GetUriLines"]["reads unloaded buffer from disk without autocmds"] = function()
+    local result = child.lua([[
+        local tools = require("LspUI.layer.tools")
+        local path = vim.fn.tempname() .. ".lua"
+        local file = io.open(path, "w")
+        for i = 1, 50 do
+            file:write(("local line_%d = %d\n"):format(i, i))
+        end
+        file:close()
+
+        local fired = 0
+        vim.api.nvim_create_autocmd(
+            { "BufReadPre", "BufReadPost", "FileType", "Syntax" },
+            { callback = function() fired = fired + 1 end }
+        )
+
+        local buf = vim.fn.bufadd(path)
+        local uri = vim.uri_from_fname(path)
+        local lines = tools.GetUriLines(buf, uri, { 0, 9, 49 })
+
+        local out = {
+            line0 = lines[0],
+            line9 = lines[9],
+            line49 = lines[49],
+            loaded = vim.api.nvim_buf_is_loaded(buf),
+            fired = fired,
+        }
+        vim.fn.delete(path)
+        return out
+    ]])
+    h.eq("local line_1 = 1", result.line0)
+    h.eq("local line_10 = 10", result.line9)
+    h.eq("local line_50 = 50", result.line49)
+    -- 关键断言：buffer 未被加载、未触发任何 BufRead/FileType 链
+    h.eq(false, result.loaded)
+    h.eq(0, result.fired)
+end
+
+T["GetUriLines"]["loaded buffer returns unsaved modifications"] = function()
+    local result = child.lua([[
+        local tools = require("LspUI.layer.tools")
+        local path = vim.fn.tempname() .. ".lua"
+        local file = io.open(path, "w")
+        file:write("on disk\n")
+        file:close()
+
+        local buf = vim.fn.bufadd(path)
+        vim.fn.bufload(buf)
+        vim.api.nvim_buf_set_lines(buf, 0, 1, false, { "modified in memory" })
+
+        local lines = tools.GetUriLines(buf, vim.uri_from_fname(path), { 0 })
+        vim.fn.delete(path)
+        return lines[0]
+    ]])
+    h.eq("modified in memory", result)
+end
+
+T["GetUriLines"]["normalizes CRLF line endings"] = function()
+    local result = child.lua([[
+        local tools = require("LspUI.layer.tools")
+        local path = vim.fn.tempname() .. ".lua"
+        local file = io.open(path, "wb")
+        file:write("local a = 1\r\nlocal b = 2\r\n")
+        file:close()
+
+        local buf = vim.fn.bufadd(path)
+        local lines = tools.GetUriLines(buf, vim.uri_from_fname(path), { 1 })
+        local out = {
+            line = lines[1],
+            has_cr = lines[1] and lines[1]:find("\r") ~= nil,
+        }
+        vim.fn.delete(path)
+        return out
+    ]])
+    h.eq("local b = 2", result.line)
+    h.eq(false, result.has_cr)
+end
+
+T["GetUriLines"]["invalid buffer falls back to disk read"] = function()
+    local result = child.lua([[
+        local tools = require("LspUI.layer.tools")
+        local path = vim.fn.tempname() .. ".lua"
+        local file = io.open(path, "w")
+        file:write("first\nsecond\n")
+        file:close()
+
+        local lines = tools.GetUriLines(99999, vim.uri_from_fname(path), { 1 })
+        vim.fn.delete(path)
+        return lines[1]
+    ]])
+    h.eq("second", result)
+end
+
+T["GetUriLines"]["missing file returns empty result"] = function()
+    local result = child.lua([[
+        local tools = require("LspUI.layer.tools")
+        local path = vim.fn.tempname() .. "_missing.lua"
+        local lines =
+            tools.GetUriLines(99999, vim.uri_from_fname(path), { 0, 1 })
+        return { count = vim.tbl_count(lines) }
+    ]])
+    h.eq(0, result.count)
+end
+
+T["GetUriLines"]["dedupes and filters invalid rows"] = function()
+    local result = child.lua([[
+        local tools = require("LspUI.layer.tools")
+        local path = vim.fn.tempname() .. ".lua"
+        local file = io.open(path, "w")
+        file:write("a\nb\nc\n")
+        file:close()
+
+        local buf = vim.fn.bufadd(path)
+        local lines = tools.GetUriLines(
+            buf,
+            vim.uri_from_fname(path),
+            { 1, 1, -5, "bad", 100 }
+        )
+        local out = {
+            line1 = lines[1],
+            count = vim.tbl_count(lines),
+        }
+        vim.fn.delete(path)
+        return out
+    ]])
+    h.eq("b", result.line1)
+    -- 行 100 超出文件末尾、-5/"bad" 非法，只应得到行 1
+    h.eq(1, result.count)
+end
+
+T["detect_filetype"]["caches results consistently"] = function()
+    local result = child.lua([[
+        local tools = require("LspUI.layer.tools")
+        local first = tools.detect_filetype("/tmp/cache_probe.lua")
+        local second = tools.detect_filetype("/tmp/cache_probe.lua")
+        local unknown_first = tools.detect_filetype("/tmp/x.someunknownext")
+        local unknown_second = tools.detect_filetype("/tmp/x.someunknownext")
+        return {
+            first = first,
+            second = second,
+            unknown_first = unknown_first,
+            unknown_second = unknown_second,
+        }
+    ]])
+    h.eq("lua", result.first)
+    h.eq(result.first, result.second)
+    -- 空结果也要被缓存且保持一致
+    h.eq(result.unknown_first, result.unknown_second)
+end
+
 T["GetUriLines"]["handles empty rows array"] = function()
     local result = child.lua([[
         local tools = require("LspUI.layer.tools")


### PR DESCRIPTION
Closes #84 (Findings 1–3).

Two independent optimizations with the same root cause: paying for the `FileType`/`Syntax`/`BufRead` autocmd chains in places that never use what those chains produce.

# Commit 1 — hover: skip legacy syntax loading when setting filetype

## Problem

`apply_treesitter_highlight` sets `filetype = "markdown"` on the hover buffer. That triggers the `syntaxset` chain, which sources `syntax/markdown.vim` and everything it includes. We highlight the hover window entirely through Treesitter, so none of it is used — and we pay for it on every single hover.

Measured in isolation (mean of 400 iterations):

| | mean ms |
|---|---|
| `filetype = "markdown"` | 5.0163 |
| `filetype = "markdown"` with `eventignore = "Syntax"` | 0.0787 |
| `vim.treesitter.start(buf, "markdown")`, no filetype | 0.0361 |

For contrast, the Treesitter work everyone assumes is the bottleneck is nearly free: `treesitter.start` 0.1282 ms, a full `parse(true)` 0.9313 ms.

The existing `vim.bo[bufnr].syntax = ""` line above it was dead code: setting `filetype` afterwards runs the syntaxset chain, which sets `syntax` again. The comment described an intent that was never actually achieved.

## Change

Temporarily add `Syntax` to `eventignore` around the assignment (preserving any pre-existing value, `pcall`-protected), and drop the dead line. `FileType` still fires, so integrations keyed on the filetype (`render-markdown.nvim` and similar) are unaffected.

## Results

Full `ClassHover:Render` path, mean of 300 iterations, nvim 0.12.4 / macOS arm64, bare config:

| document | before | after | speedup |
|---|---|---|---|
| 23 lines | 4.68 ms | 0.20 ms | 23x |
| 39 lines | 4.72 ms | 0.21 ms | 22x |
| 95 lines | 4.71 ms | 0.23 ms | 21x |

Verified unchanged: `ft="markdown"`, Treesitter highlighter attached, captures resolve (including Go code-block injection), conceal settings intact, `gx` resolves every link form end-to-end through a fake LSP server.

# Commit 2 — views: read unloaded files from disk instead of bufload

## Problem

Opening a reference/definition view calls `GetUriLines` for every URI in the result list, which `bufload`ed every file not already open. Measured: `bufload` fires the **full** `BufReadPre/BufReadPost/FileType/Syntax/BufEnter` chain per file:

```
bufload fires: BufReadPre BufReadPost BufRead FileType Syntax BufEnter
```

| per 200-line file | mean ms |
|---|---|
| `fn.bufload` | 0.88 |
| `fn.readfile` | 0.035 |

So a 30-file reference list effectively "opened" 30 files. On a bare config that is ~26 ms; on a real config every `FileType` also triggers LSP attach (`vim.lsp.enable` hooks FileType), gitsigns, and every other BufRead-keyed plugin — for files the user merely sees in a list — and they all pollute the buffer list.

## Change

- **`GetUriLines`**: buffer not loaded → read only the needed rows from disk (`io.lines`, stops at the highest requested row, CRLF normalized). Loaded buffers keep using `nvim_buf_get_lines`, so unsaved modifications stay visible. Non-file URIs fall back to the old bufload path.
- **`sub_view` / `source_highlight`**: the deferred highlight pass for unloaded sources no longer bufloads them either. It parses the code text already shown in the subview line with `vim.treesitter.get_string_parser` (new `extract_text_highlights` / `apply_text_highlights`, bounded lang+text cache) — a file merely listed in the view is now never loaded at all. That deferred pass was previously dead code: `GetUriLines` had already synchronously loaded everything before it ran.
- **`detect_filetype`**: cache path → filetype (0.033 ms per `vim.filetype.match`, queried repeatedly per render; cache hit ~0).

## Results

30-file reference list, 5 rows per file, bare config, paired runs on main vs this branch:

| | before | after |
|---|---|---|
| time | 30.47 ms | 3.37 ms (**9x**) |
| autocmds fired | 150 | **0** |
| buffers loaded | 30 | **0** |

The autocmd/buffer columns are the real-world win: on user configs each of those 150 events fans out into LSP attach and plugin hooks that dwarf the milliseconds measured here.

String-parser extraction: 0.05 ms per distinct line, cache hits free. Correctness checks: unsaved buffer edits still shown, CRLF files normalized, invalid-buffer + valid-URI now returns disk content, extmarks land with correct `@` capture groups.

# Interactive paths audited and left alone

Per-keystroke/cursor paths measured and already clean — no changes needed: `signature_handle` early-exit ~0.0000 ms, `tools.debounce` timer churn 0.0004 ms, `extract_line_highlights` cache hit 0.0005 ms, `GetUriLines` on loaded buffers 0.010 ms.

# Tests

268 cases pass. Commit 3 adds coverage for every new path, since `GetUriLines` previously only had loaded-buffer cases and `source_highlight` had no test file at all:

- `GetUriLines`: disk read keeps the buffer unloaded and fires **zero** BufRead/FileType/Syntax autocmds; loaded buffers return unsaved in-memory edits; CRLF normalized; invalid buffer + valid URI falls back to disk; missing file returns empty; duplicate/negative/non-numeric/beyond-EOF rows filtered
- `detect_filetype`: cache consistency, including the empty-result case
- `extract_text_highlights` / `apply_text_highlights`: @-prefixed groups within bounds, extmark offsets respect `col_start`, unknown language / empty input / invalid range return nothing, cache hit returns the identical table
- `sub_view.ApplySyntaxHighlight`: unloaded source gets treesitter extmarks via the scheduled string-parser pass while staying unloaded with zero autocmds; loaded source still takes the synchronous buffer path

`stylua --check .` clean.

# Still open on #84

- Finding 4 — whether the `max_width * 0.5` width cap is intentional (design question, not performance)

